### PR TITLE
Detect DISCNUMBER tag without DISCTOTAL

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,4 @@ Changes implemented:
 - Bugfix for https://github.com/gs11/sonerezh/issues/7 (Re-parsing of metadata for modified files)
 - Fixed detection of tag 'DISCNUMBER' without 'DISCTOTAL' for OGG files
 - Fixed detection of disc number without a disc total in the string (e.g. '01' instead of '01/02')
+- Fixed year not showing for album with multiple CDs

--- a/README.md
+++ b/README.md
@@ -33,3 +33,5 @@ Changes implemented:
 - Fixed some magic numbers in code
 - Merged commit in PR https://github.com/Sonerezh/sonerezh/pull/312 (Player now shows artist instead of band)
 - Bugfix for https://github.com/gs11/sonerezh/issues/7 (Re-parsing of metadata for modified files)
+- Fixed detection of tag 'DISCNUMBER' without 'DISCTOTAL' for OGG files
+- Fixed detection of disc number without a disc total in the string (e.g. '01' instead of '01/02')

--- a/app/Controller/Component/SortComponent.php
+++ b/app/Controller/Component/SortComponent.php
@@ -19,7 +19,7 @@ class SortComponent extends Component {
      */
     public function sortByBand($songs) {
         foreach ($songs as $key => $row) {
-            $s_discs = preg_split('/\//', $row['Song']['disc']);
+            $s_discs = explode('/', $row['Song']['disc']);
             $s_band[$key]           = $row['Song']['band'];
             $s_album[$key]          = $row['Song']['album'];
             $s_track_number[$key]   = $row['Song']['track_number'];
@@ -43,7 +43,7 @@ class SortComponent extends Component {
      */
     public function sortByDisc($songs) {
         foreach ($songs as $key => $row) {
-            $s_discs = preg_split('/\//', $row['Song']['disc']);
+            $s_discs = explode('/', $row['Song']['disc']);
             $s_track_number[$key]   = $row['Song']['track_number'];
             $s_disc[$key]           = $s_discs[0];
         }

--- a/app/Controller/SongsController.php
+++ b/app/Controller/SongsController.php
@@ -384,13 +384,12 @@ class SongsController extends AppController {
 
         $parsed = array();
         foreach ($songs as &$song) {
-            $setsQuantity = explode('/', $song['Song']['disc']);
-
-            if (count($setsQuantity) < 2 || $setsQuantity[1] == '1') {
-                $currentDisc = '1';
-            } else {
+            $currentDisc = 1;
+            if (!empty($song['Song']['disc'])) {
+                $setsQuantity = explode('/', $song['Song']['disc']);
                 $currentDisc = $setsQuantity[0];
             }
+
             $parsed[$currentDisc][] = $song;
         }
 
@@ -439,11 +438,9 @@ class SongsController extends AppController {
         // Then we can group the songs by band name, album and disc.
         $parsed = array();
         foreach ($songs as $song) {
-            $setsQuantity = preg_split('/\//', $song['Song']['disc']);
-
-            if (count($setsQuantity) < 2 || $setsQuantity[1] == '1') {
-                $currentDisc = '1';
-            } else {
+            $currentDisc = 1;
+            if (!empty($song['Song']['disc'])) {
+                $setsQuantity = explode('/', $song['Song']['disc']);
                 $currentDisc = $setsQuantity[0];
             }
 
@@ -567,11 +564,9 @@ class SongsController extends AppController {
 
             $parsed = array();
             foreach ($songs as $song) {
-                $setsQuantity = preg_split('/\//', $song['Song']['disc']);
-
-                if (count($setsQuantity) < 2 || $setsQuantity[1] == '1'  ) {
-                    $currentDisc = '1';
-                } else {
+                $currentDisc = 1;
+                if (!empty($song['Song']['disc'])) {
+                    $setsQuantity = explode('/', $song['Song']['disc']);
                     $currentDisc = $setsQuantity[0];
                 }
 

--- a/app/Controller/SongsController.php
+++ b/app/Controller/SongsController.php
@@ -387,7 +387,7 @@ class SongsController extends AppController {
             $currentDisc = 1;
             if (!empty($song['Song']['disc'])) {
                 $setsQuantity = explode('/', $song['Song']['disc']);
-                $currentDisc = $setsQuantity[0];
+                $currentDisc = (int)($setsQuantity[0]);
             }
 
             $parsed[$currentDisc][] = $song;
@@ -441,7 +441,7 @@ class SongsController extends AppController {
             $currentDisc = 1;
             if (!empty($song['Song']['disc'])) {
                 $setsQuantity = explode('/', $song['Song']['disc']);
-                $currentDisc = $setsQuantity[0];
+                $currentDisc = (int)($setsQuantity[0]);
             }
 
             if (!isset($parsed[$song['Song']['band']]['albums'][$song['Song']['album']])) {
@@ -567,7 +567,7 @@ class SongsController extends AppController {
                 $currentDisc = 1;
                 if (!empty($song['Song']['disc'])) {
                     $setsQuantity = explode('/', $song['Song']['disc']);
-                    $currentDisc = $setsQuantity[0];
+                    $currentDisc = (int)($setsQuantity[0]);
                 }
 
                 if (!isset($parsed[$song['Song']['band']]['albums'][$song['Song']['album']])) {

--- a/app/Lib/SongManager/SongManager.php
+++ b/app/Lib/SongManager/SongManager.php
@@ -100,8 +100,11 @@ class SongManager {
         // Song set
         if (!empty($file_infos['comments']['part_of_a_set'])) {     // MP3 Tag
             $metadata['disc'] = end($file_infos['comments']['part_of_a_set']);
-        } elseif (!empty($file_infos['comments']['discnumber']) && !empty($file_infos['comments']['disctotal'])) {  // OGG Tag
-            $metadata['disc'] = end($file_infos['comments']['discnumber']) . '/' . end($file_infos['comments']['disctotal']);
+        } elseif (!empty($file_infos['comments']['discnumber'])) {  // OGG Tag
+            $metadata['disc'] = end($file_infos['comments']['discnumber']);
+            if (!empty($file_infos['comments']['disctotal'])) {
+                $metadata['disc'] .= '/' . end($file_infos['comments']['disctotal']);
+            }
         }
 
         // Song genre


### PR DESCRIPTION
For mp3 files, the "Part Of a Set" tag (`TPOS`) can be either a single
number, or two numbers separated by a '/' [1].

Sonerezh always wanted two numbers separated by a '/', and, for ogg
files, only filled the disc tag if both DISCNUMBER and DISCTOTAL existed.

This fix does two things:
1. For ogg files, DISCTOTAL is now optional
2. Handle both formats, i.e. w/ and w/o '/'

[1] http://id3.org/id3v2.3.0